### PR TITLE
[TASK] Prettify output for properties with an OptionProvider

### DIFF
--- a/Documentation/Pages/ViewHelpers/Property.rst
+++ b/Documentation/Pages/ViewHelpers/Property.rst
@@ -2,7 +2,11 @@ Property
 --------
 
 
-You can use this viewHelper to retrieve a property from ab object based on the name of the property stored in a variabl
+You can use this viewHelper to retrieve a property´s value from ab object based on the name or the schema of the property.
+Properties with an Array OptionProvider defined, will be mapped to the option label with the current value used as index
+
+Properties with a Relation OptionProvider defined, will show up with the value of the property defined on the LabelPath
+(the last feature is only supported when you pass the propertyschema instead of the properties name)
 
 Example
 =======
@@ -10,7 +14,7 @@ Example
 .. code-block:: html
 
   <f:for each="{properties}" as="property">
-    <e:property object="{object}" name="{property}" />
+    <e:property object="{object}" property="{property}" />
   </f:for>
 
 
@@ -18,10 +22,11 @@ Example
 Arguments
 =========
 
-======  ======  ========  ===============================================
-Name    Type    Required  Description                                      
-======  ======  ========  ===============================================
-object  object  yes       Object to get the property or propertyPath from  
-name    string  yes       Name of the property or propertyPath             
-======  ======  ========  ===============================================
+========  ======  ========  ===============================================
+Name      Type    Required  Description
+========  ======  ========  ===============================================
+object    object  yes       Object to get the property or propertyPath from
+name      string  yes       Name of the property or propertyPath
+property  object  yes       The property´s schema
+========  ======  ========  ===============================================
 

--- a/Resources/Private/Partials/Table/Body.html
+++ b/Resources/Private/Partials/Table/Body.html
@@ -6,7 +6,7 @@
 		</td>
 		<f:for each="{schema.listProperties}" as="property" iteration="iteration">
 			<td>
-				<e:property object="{entity}" name="{property.path}" />
+				<e:property object="{entity}" property="{property}" />
 				<f:if condition="{iteration.isFirst}">
 					<div class="expose-actions">
 						<f:render partial="Table/Actions" arguments="{entity: entity, controller: controller}" />


### PR DESCRIPTION
Properties with an Array OptionProvider defined, will be mapped to the option label with the current value used as index

Properties with a Relation OptionProvider defined, will show up with the value of the property defined on the LabelPath (this feature is only supported when you pass the propertyschema instead of the properties name)